### PR TITLE
Import buttonmap.xml

### DIFF
--- a/game.libretro.beetle-lynx/addon.xml.in
+++ b/game.libretro.beetle-lynx/addon.xml.in
@@ -5,6 +5,7 @@
 		provider-name="Libretro">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
+		<import addon="game.controller.atari.lynx" version="1.0.0"/>
 	</requires>
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">

--- a/game.libretro.beetle-lynx/resources/buttonmap.xml
+++ b/game.libretro.beetle-lynx/resources/buttonmap.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<buttonmap version="2">
+	<controller id="game.controller.atari.lynx" type="RETRO_DEVICE_JOYPAD">
+		<feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
+		<feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
+		<feature name="option1" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
+		<feature name="option2" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
+		<feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
+		<feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
+		<feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
+		<feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
+		<feature name="pause" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
+	</controller>
+</buttonmap>


### PR DESCRIPTION
Data comes from Beetle Lynx source:

https://github.com/libretro/beetle-lynx-libretro/blob/master/libretro.cpp

topology.xml is not needed because Kodi defaults to a single port that accepts the controllers listed in addon.xml.